### PR TITLE
Add SignatureWork date-gated banner; fix homepage anchor jump

### DIFF
--- a/_pages/about.html
+++ b/_pages/about.html
@@ -10,6 +10,16 @@ redirect_from:
 
 {% include base_path %}
 
+{% assign banner_until = "2026-04-25" | date: "%Y-%m-%d" %}
+{% assign today = site.time | date: "%Y-%m-%d" %}
+{% if today <= banner_until %}
+<aside class="hp-banner" role="note">
+  <span class="hp-banner-tag">Apr 17 · Now</span>
+  <span class="hp-banner-msg">Welcome from the SignatureWork poster session</span>
+  <a class="hp-banner-cta" href="#minn">Jump to MINN <span aria-hidden="true">↓</span></a>
+</aside>
+{% endif %}
+
 <h1 class="hp-name">Juntang Wang</h1>
 
 <div class="hp-profile">
@@ -60,7 +70,7 @@ redirect_from:
   <p class="hp-note"><sup>†</sup> denotes equal contribution; only first and co-first authored papers are listed</p>
   {% assign featured_pubs = site.publications | where: "featured", true | sort: "date" | reverse %}
   {% for pub in featured_pubs %}
-  <div class="hp-pub{% if pub.highlighted %} hp-pub--highlight{% endif %}">
+  <div class="hp-pub{% if pub.highlighted %} hp-pub--highlight{% endif %}" id="{{ pub.anchor }}">
     <h3 class="hp-pub-title">
       <a href="{{ base_path }}/publications/#{{ pub.anchor }}">{{ pub.title }}</a>
     </h3>

--- a/_sass/layout/_homepage.scss
+++ b/_sass/layout/_homepage.scss
@@ -2,6 +2,66 @@
    HOMEPAGE — Min Liu–inspired, CSS-var dark mode
    ========================================================================== */
 
+html { scroll-behavior: smooth; }
+
+.hp-banner {
+  max-width: 820px;
+  margin: 1.5em auto 0;
+  padding: 0.7em 1em 0.7em 0.9em;
+  display: flex;
+  align-items: center;
+  gap: 0.95em;
+  background: var(--hp-highlight-bg);
+  border-radius: 6px;
+  font-family: Palatino, Georgia, "Times New Roman", serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--global-text-color);
+
+  .hp-banner-tag {
+    font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+    font-size: 10.5px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.09em;
+    color: #fff;
+    background: var(--global-base-color);
+    padding: 0.3em 0.6em 0.25em;
+    border-radius: 3px;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .hp-banner-msg {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .hp-banner-cta {
+    color: var(--global-link-color);
+    text-decoration: none;
+    font-weight: 600;
+    white-space: nowrap;
+    flex-shrink: 0;
+
+    &:hover {
+      color: var(--global-link-color-hover);
+      text-decoration: underline;
+    }
+  }
+}
+
+@media (max-width: 600px) {
+  .hp-banner {
+    flex-wrap: wrap;
+    row-gap: 0.45em;
+
+    .hp-banner-msg { flex-basis: 100%; order: 3; }
+    .hp-banner-tag { order: 1; }
+    .hp-banner-cta { order: 2; margin-left: auto; }
+  }
+}
+
 .homepage {
   max-width: 820px;
   margin: 0 auto;
@@ -118,6 +178,7 @@
   /* --- Publication entry --- */
   .hp-pub {
     margin-bottom: 1.6em;
+    scroll-margin-top: 90px;
   }
 
   .hp-pub.hp-pub--highlight {


### PR DESCRIPTION
## Summary
- Adds a polished, date-gated banner at the top of the homepage so QR-scanners landing during the symposium window immediately see where to go.
- Auto-hides after 2026-04-25 via a Liquid date gate — no manual cleanup.
- Fixes the broken \`#minn\` anchor: the homepage card now carries \`id=\"minn\"\` (it previously only existed on \`/publications/\`).
- Adds \`scroll-behavior: smooth\` and \`scroll-margin-top: 90px\` on \`.hp-pub\` so the target lands clear of the fixed 70px masthead.

## Test plan
- [x] Local build clean
- [x] Banner renders with crimson date pill + welcome msg + right-aligned CTA
- [x] Clicking 'Jump to MINN ↓' smooth-scrolls to the highlighted card with masthead clearance
- [ ] Banner disappears for builds dated > 2026-04-25
- [ ] Mobile (≤600px) wraps cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)