### PR TITLE
Drop the two news entries added today

### DIFF
--- a/_pages/about.html
+++ b/_pages/about.html
@@ -44,8 +44,6 @@ redirect_from:
 <div class="hp-section">
   <h2 class="hp-section-heading">News</h2>
   <ul class="hp-news">
-    <li>[Aug, 2026] Presenting <a href="{{ base_path }}/publications/#stageguard">StageGuard</a> at <strong class="hp-pub-award">KDD 2026</strong> in Jeju, Korea.</li>
-    <li>[Jul, 2026] <a href="{{ base_path }}/publications/#stageguard">StageGuard</a> is now on <a href="https://arxiv.org/abs/2607.23284">arXiv</a>.</li>
     <li>[May, 2026] <a href="{{ base_path }}/publications/#stageguard">StageGuard</a> is accepted to <strong class="hp-pub-award">KDD 2026</strong> AI for Science Track (Inaugural).</li>
     <li>[May, 2026] Conferred B.S. with Distinction and <em>cum laude</em> from Duke &amp; DKU.</li>
     <li>[May, 2026] <a href="{{ base_path }}/publications/#mixconfig">MixConfig</a> is accepted to <strong class="hp-pub-award">ICML 2026</strong>.</li>


### PR DESCRIPTION
Removes the two news entries added earlier today.

```
[Aug, 2026] Presenting StageGuard at KDD 2026 in Jeju, Korea.
[Jul, 2026] StageGuard is now on arXiv.
```

Both restated things the page already carried. The arXiv posting is already a link on the StageGuard publication entry, and "presenting at KDD" follows directly from the May acceptance line that sat immediately below it. Three consecutive StageGuard lines at the top of News was repetition, not news.

Back to one line per genuinely new fact. Build clean, seven entries, top one is the May KDD acceptance.