### PR TITLE
Point the StageGuard paper link at the ACM DOI

### DIFF
--- a/_publications/2026-05-16-StageGuard-KDD2026.md
+++ b/_publications/2026-05-16-StageGuard-KDD2026.md
@@ -6,9 +6,9 @@ date: 2026-05-16
 venue: 'ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD) — AI for Science Track (Inaugural)'
 venue_short: 'KDD'
 track: 'AI for Science Track (Inaugural)'
-citation: '<strong>Juntang Wang</strong><sup>†</sup>, Yihan Wang<sup>†</sup>, Hao Wu<sup>†</sup>, Jiayu Gao, Shixin Xu, and Dongmian Zou. (2026). &quot;StageGuard: Physiologically Constrained Sleep Staging.&quot; <i>KDD 2026 AI for Science Track (Inaugural)</i>. <a href="https://openreview.net/forum?id=LEwjtvV1VK">OpenReview</a>'
+citation: '<strong>Juntang Wang</strong><sup>†</sup>, Yihan Wang<sup>†</sup>, Hao Wu<sup>†</sup>, Jiayu Gao, Shixin Xu, and Dongmian Zou. (2026). &quot;StageGuard: Physiologically Constrained Sleep Staging.&quot; <i>KDD 2026 AI for Science Track (Inaugural)</i>. <a href="https://doi.org/10.1145/3770855.3818916">ACM DL</a>'
 anchor: stageguard
-paperurl: 'https://openreview.net/forum?id=LEwjtvV1VK'
+paperurl: 'https://doi.org/10.1145/3770855.3818916'
 arxivurl: 'https://arxiv.org/abs/2607.23284'
 posterurl: '/files/p03-KDD2026-StageGuard-poster.pdf'
 codeurl: 'https://github.com/Q9gJYx/StageGuard'


### PR DESCRIPTION
KDD '26 proceedings are deposited. Verified against Crossref:

| Field | Value |
|:--|:--|
| DOI | `10.1145/3770855.3818916` |
| Proceedings | Proceedings of the 32nd ACM SIGKDD Conference on KDD **V.2** |
| Pages | 12267-12278 |
| Crossref record created | 2026-08-06 |
| Official publication date | 2026-08-08 |

## Change

`_publications/2026-05-16-StageGuard-KDD2026.md`: `paperurl` and the citation's trailing hyperlink move from the OpenReview forum to the DOI. The rendered link row keeps its shape (`paper / poster / code / arXiv`); `paper` now resolves to the ACM DL entry.

The OpenReview link is dropped rather than kept alongside: the DOI is the version of record and permanent, and `arxivurl` already covers free reading.

## Caveat

`dl.acm.org` sits behind Cloudflare and returns 403 to every automated request, for both the article page and the proceedings TOC. A bot-block is indistinguishable from a missing page, so the landing page could not be render-verified. The DOI itself resolves (`doi.org` 302 to `dl.acm.org/doi/10.1145/3770855.3818916`), and assigned page numbers plus a volume mean the proceedings are finalized. Worth one manual click before merging, since the stamped issue date is 2026-08-08.
