### PR TITLE
Keep logo rows side by side on phones; trim and level the News list

### DIFF
--- a/_pages/about.html
+++ b/_pages/about.html
@@ -45,10 +45,9 @@ redirect_from:
   <h2 class="hp-section-heading">News</h2>
   <ul class="hp-news">
     <li>[May, 2026] <a href="{{ base_path }}/publications/#stageguard">StageGuard</a> is accepted to <strong class="hp-pub-award">KDD 2026</strong> AI for Science Track (Inaugural).</li>
-    <li>[May, 2026] Conferred B.S. with Distinction and <em>cum laude</em> from Duke &amp; DKU.</li>
     <li>[May, 2026] <a href="{{ base_path }}/publications/#mixconfig">MixConfig</a> is accepted to <strong class="hp-pub-award">ICML 2026</strong>.</li>
-    <li>[Apr, 2026] Presented MINN at DKU SignatureWork 2026.</li>
-    <li>[Nov, 2025] <a href="{{ base_path }}/publications/#infantconfig">InfantConfig</a> has been selected for <strong class="hp-pub-award">Oral Presentation</strong> at BICS 2025.</li>
+    <li>[Apr, 2026] MINN is presented at DKU SignatureWork 2026.</li>
+    <li>[Nov, 2025] <a href="{{ base_path }}/publications/#infantconfig">InfantConfig</a> is selected for <strong class="hp-pub-award">Oral Presentation</strong> at BICS 2025.</li>
     <li>[Sep, 2025] <a href="{{ base_path }}/publications/#martianclock">MartianClock</a> is accepted to CNS 2025.</li>
     <li>[Jul, 2025] <a href="{{ base_path }}/publications/#lk99">TempLK99</a> is accepted to MC17.</li>
   </ul>

--- a/_sass/layout/_homepage.scss
+++ b/_sass/layout/_homepage.scss
@@ -280,11 +280,11 @@ html { scroll-behavior: smooth; }
   }
 
   /* --- Logo placeholder (work + education) --- */
+  /* Matches the real logo box exactly so a missing logo does not shift the
+     text column relative to its neighbours. */
   .hp-logo-placeholder {
-    width: 65%;
-    max-width: 90px;
+    width: 56px;
     height: 56px;
-    margin: 0 auto;
     background-color: var(--global-border-color);
     border-radius: 6px;
     opacity: 0.5;
@@ -328,17 +328,24 @@ html { scroll-behavior: smooth; }
       text-align: left;
     }
 
+    /* Stay side by side: logo pinned left, text block right. Stacking the
+       logo above the text made each entry read as two unrelated fragments
+       and left the logos on a ragged edge. */
     .hp-edu-row,
     .hp-work-row {
-      flex-direction: column;
-      align-items: flex-start;
+      align-items: center;
+      gap: 14px;
     }
 
     .hp-edu-logo,
     .hp-work-logo {
-      flex: none;
-      margin-bottom: 0.4em;
+      flex: 0 0 48px;
       img { width: 48px; height: 48px; }
+    }
+
+    .hp-logo-placeholder {
+      width: 48px;
+      height: 48px;
     }
   }
 }


### PR DESCRIPTION
Two changes, previewed locally before commit.

## 1. Education and Work rows on phones

At `<=640px` the rows flipped to `flex-direction: column`, putting each logo on its own line above the text. Each entry read as two unrelated fragments, and since the logo box collapsed to content width, the logos sat on a ragged left edge.

Rows now stay horizontal at every width: logo pinned left in a fixed `48px` column, text to its right, gap tightened `24px -> 14px` to earn back horizontal space.

`.hp-logo-placeholder` now matches the real logo box (`56px` desktop, `48px` mobile). It was `width: 65%` with `margin: 0 auto`, so the Dahan Intelligence row centred its placeholder while Siemens and Huaxia left-aligned their images, starting all three work rows at a different x.

## 2. News list

- Dropped the B.S. conferral entry. News is now paper and venue events only.
- MINN entry reordered to lead with the subject: `MINN is presented at DKU SignatureWork 2026`.
- Tense settled on simple present across all six entries. `has been selected` became `is selected`.

Five of seven entries already read `X is accepted to Y`, so the outliers moved to match rather than the reverse. The bracketed date carries the time, which is what makes present tense work here.

## Note

The MINN entry stays unlinked while every other news item links to `/publications/#anchor`. Its publication file carries `published: false`, so Jekyll drops it from the site and `/publications/#minn` resolves to nothing. Verified against the local build: rendered anchors are `stageguard`, `mixconfig`, `infantconfig`, `martianclock`, `lk99`. Flip that flag and the link can be added.
